### PR TITLE
Changed 'splitted' to 'split' wherever it appears in page content

### DIFF
--- a/Documentation:Repository:Meta-Packages.php
+++ b/Documentation:Repository:Meta-Packages.php
@@ -7,7 +7,7 @@ include_once("includes/header.php");
 ?>
 
 <p>
-    This section describes all the meta-packages available in the KXStudio repositories, splitted by type.
+    This section describes all the meta-packages available in the KXStudio repositories, split by type.
 </p>
 
 <h3><span class="mw-headline" id="MetaPackageList">KXStudio own package list</span></h3>

--- a/ns/canvas/split.php
+++ b/ns/canvas/split.php
@@ -7,7 +7,7 @@ include_once("../../includes/header.php");
 ?>
 
 <p>
-    Wherever the group/client has a splitted box in the canvas
+    Wherever the group/client has a split box in the canvas
 </p>
 <p>
     <b>Default:</b> None/Unset.<br/>

--- a/ns/canvas/x_split.php
+++ b/ns/canvas/x_split.php
@@ -7,7 +7,7 @@ include_once("../../includes/header.php");
 ?>
 
 <p>
-    Group/Client splitted-box position in the canvas (horizontal)
+    Group/Client split-box position in the canvas (horizontal)
 </p>
 <p>
     <b>Default:</b> None/Unset.<br/>

--- a/ns/canvas/y_split.php
+++ b/ns/canvas/y_split.php
@@ -7,7 +7,7 @@ include_once("../../includes/header.php");
 ?>
 
 <p>
-    Group/Client splitted-box position in the canvas (vertical)
+    Group/Client split-box position in the canvas (vertical)
 </p>
 <p>
     <b>Default:</b> None/Unset.<br/>


### PR DESCRIPTION
This is a nitpick, but "splitted" is considered archaic/nonstandard by most dictionaries. This isn't a full spellcheck, I just saw the word and felt like fixing it if possible.

I've changed this to "split" where it appears in page content. It also appears is in a changelog comment, but I left that as-is.

I noticed that [pushing changes triggers an RSS feed announcement](https://github.com/KXStudio/Website/pull/12#issuecomment-473467630), if this is still the case it would probably be best to move this to a new 'beta' branch, to be merged in later with more substantive changes.